### PR TITLE
Fix documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ formatVerboseDate : PropTypes.func,
 // `Intl.DateTimeFormat` format for the HTML `title` tooltip attribute.
 // Is used when `formatVerboseDate` is not specified.
 // By default outputs a verbose date.
-verboseDateTimeFormat : PropTypes.object,
+verboseDateFormat : PropTypes.object,
 
 // How often to update all `<ReactTimeAgo/>` elements on a page.
 // (is once in a minute by default)

--- a/source/ReactTimeAgo.js
+++ b/source/ReactTimeAgo.js
@@ -32,7 +32,7 @@ export default class ReactTimeAgo extends PureComponent
 		locales : PropTypes.arrayOf(PropTypes.string),
 
 		// Date/time formatting style.
-		// E.g. 'twitter', 'fuzzy', or custom (`{ gradation: […], units: […], flavour: 'long', custom: function }`)
+		// E.g. 'twitter', 'time', or custom (`{ gradation: […], units: […], flavour: 'long', custom: function }`)
 		timeStyle : style,
 
 		// Whether HTML `tooltip` attribute should be set


### PR DESCRIPTION
- `verboseDateTimeFormat`  renamed to `verboseDateFormat`
- `fuzzy` renamed to `time`